### PR TITLE
refactor[LLM_CONFIG]: restore mesh shape and axes_name in MeshConfig

### DIFF
--- a/llm_config/api.py
+++ b/llm_config/api.py
@@ -10,9 +10,9 @@ from llm_config.configs import (
   MLPConfig,
   ModelConfig,
   MoEConfig,
+  ParallelismConfig,
   RMSNormConfig,
   RopeConfig,
-  ParallelismConfig,
 )
 
 INDENTATION_STRIDE = 2
@@ -28,7 +28,7 @@ CONFIG_MAP = {
   "moe": MoEConfig,
   "mlp": MLPConfig,
   "norm": RMSNormConfig,
-  "parallelism": ParallelismConfig
+  "parallelism": ParallelismConfig,
 }
 ATTRS_MAP = {
   "mesh": "mesh_config",

--- a/llm_config/api.py
+++ b/llm_config/api.py
@@ -12,6 +12,7 @@ from llm_config.configs import (
   MoEConfig,
   RMSNormConfig,
   RopeConfig,
+  ParallelismConfig,
 )
 
 INDENTATION_STRIDE = 2
@@ -27,6 +28,7 @@ CONFIG_MAP = {
   "moe": MoEConfig,
   "mlp": MLPConfig,
   "norm": RMSNormConfig,
+  "parallelism": ParallelismConfig
 }
 ATTRS_MAP = {
   "mesh": "mesh_config",
@@ -37,6 +39,7 @@ ATTRS_MAP = {
   "moe": "moe_config",
   "mlp": "mlp_config",
   "norm": "rmsnorm_config",
+  "parallelism": "parallelism_config",
 }
 REVERSE_ATTRS_MAP = dict(zip(ATTRS_MAP.values(), ATTRS_MAP.keys(), strict=True))
 ATTRS_NAME_MAP = {
@@ -48,6 +51,7 @@ ATTRS_NAME_MAP = {
   "moe": "moe_config_name",
   "mlp": "mlp_config_name",
   "norm": "rmsnorm_config_name",
+  "parallelism": "parallelism_config_name",
 }
 
 

--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -62,6 +62,12 @@ class MeshConfig(Base):
     MutableList.as_mutable(JSON), nullable=True, default=None
   )
   hardware: Mapped[Hardware] = mapped_column(Enum(Hardware), default=Hardware.CPU)
+  topology: Mapped[str] = mapped_column(
+    String,
+    nullable=True,
+    default=None,
+    comment="Physical device topology descriptor for the mesh.",
+  )
 
 
 # ==============================================================================

--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -17,6 +17,7 @@ __all__ = [
   "ModelConfig",
   "RMSNormConfig",
   "RopeConfig",
+  "ParallelismConfig",
 ]
 
 
@@ -138,6 +139,15 @@ class ModelConfig(Base):
   embed_config: Mapped["EmbeddingConfig"] = relationship(
     back_populates="model_config", init=False, lazy="immediate"
   )
+  parallelism_config_name: Mapped[str] = mapped_column(
+  ForeignKey("ParallelismConfig.name"), nullable=True, default=None
+  )
+  parallelism_config: Mapped["ParallelismConfig"] = relationship(
+    back_populates="model_config",
+    init=False,
+    lazy="immediate",
+  )
+
 
   export_mlp: Mapped[bool] = mapped_column(Boolean, default=True)
   export_moe: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -404,3 +414,24 @@ class RMSNormConfig(Base):
     MutableList.as_mutable(JSON), nullable=True, default=None
   )
   weight_dtype: Mapped[Dtype] = mapped_column(Enum(Dtype), default=Dtype.FLOAT32)
+  
+  
+# ==============================================================================
+# Parallelism
+# ==============================================================================
+class ParallelismConfig(Base):
+  __tablename__ = "ParallelismConfig"
+
+  model_config: Mapped[list["ModelConfig"] | None] = relationship(
+    back_populates="parallelism_config",
+    cascade="all, delete-orphan",
+    init=False,
+    lazy="immediate",
+  )
+
+  tp: Mapped[int] = mapped_column(Integer, default=1)
+  dp: Mapped[int] = mapped_column(Integer, default=1)
+  fsdp: Mapped[int] = mapped_column(Integer, default=1)
+  cp: Mapped[int] = mapped_column(Integer, default=1)
+  ep: Mapped[int] = mapped_column(Integer, default=1)
+  axis_order: Mapped[str] = mapped_column(String, default="")

--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -55,12 +55,6 @@ class MeshConfig(Base):
     lazy="immediate",
   )
 
-  axes_name: Mapped[list[str]] = mapped_column(
-    MutableList.as_mutable(JSON), nullable=True, default=None
-  )
-  shape: Mapped[list[int]] = mapped_column(
-    MutableList.as_mutable(JSON), nullable=True, default=None
-  )
   hardware: Mapped[Hardware] = mapped_column(Enum(Hardware), default=Hardware.CPU)
   topology: Mapped[str] = mapped_column(
     String,

--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -15,9 +15,9 @@ __all__ = [
   "MeshConfig",
   "MoEConfig",
   "ModelConfig",
+  "ParallelismConfig",
   "RMSNormConfig",
   "RopeConfig",
-  "ParallelismConfig",
 ]
 
 
@@ -140,14 +140,13 @@ class ModelConfig(Base):
     back_populates="model_config", init=False, lazy="immediate"
   )
   parallelism_config_name: Mapped[str] = mapped_column(
-  ForeignKey("ParallelismConfig.name"), nullable=True, default=None
+    ForeignKey("ParallelismConfig.name"), nullable=True, default=None
   )
   parallelism_config: Mapped["ParallelismConfig"] = relationship(
     back_populates="model_config",
     init=False,
     lazy="immediate",
   )
-
 
   export_mlp: Mapped[bool] = mapped_column(Boolean, default=True)
   export_moe: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -414,8 +413,8 @@ class RMSNormConfig(Base):
     MutableList.as_mutable(JSON), nullable=True, default=None
   )
   weight_dtype: Mapped[Dtype] = mapped_column(Enum(Dtype), default=Dtype.FLOAT32)
-  
-  
+
+
 # ==============================================================================
 # Parallelism
 # ==============================================================================

--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -55,6 +55,12 @@ class MeshConfig(Base):
     lazy="immediate",
   )
 
+  axes_name: Mapped[list[str]] = mapped_column(
+    MutableList.as_mutable(JSON), nullable=True, default=None
+  )
+  shape: Mapped[list[int]] = mapped_column(
+    MutableList.as_mutable(JSON), nullable=True, default=None
+  )
   hardware: Mapped[Hardware] = mapped_column(Enum(Hardware), default=Hardware.CPU)
   topology: Mapped[str] = mapped_column(
     String,


### PR DESCRIPTION
Problem:
  - The previous refactor removed mesh shape and axes_name from MeshConfig
  - Existing config consumers still rely on these fields

Solution:
  - Restore shape field in MeshConfig
  - Restore axes_name field in MeshConfig

Test:
  - ruff check

JIRA: PDIST-425