### PR TITLE
refactor[LLM_CONFIG]: restore mesh shape and axes_name in MeshConfig

### DIFF
--- a/llm_config/configs.py
+++ b/llm_config/configs.py
@@ -55,6 +55,12 @@ class MeshConfig(Base):
     lazy="immediate",
   )
 
+  axes_name: Mapped[list[str]] = mapped_column(
+    MutableList.as_mutable(JSON), nullable=True, default=None
+  )
+  shape: Mapped[list[int]] = mapped_column(
+    MutableList.as_mutable(JSON), nullable=True, default=None
+  )
   hardware: Mapped[Hardware] = mapped_column(Enum(Hardware), default=Hardware.CPU)
   topology: Mapped[str] = mapped_column(
     String,


### PR DESCRIPTION
Problem:
  - The previous refactor removed mesh shape and axes_name from MeshConfig
  - Existing config consumers still rely on these fields

Solution:
  - Restore shape field in MeshConfig
  - Restore axes_name field in MeshConfig

Test:
  - ruff check

JIRA: PDIST-425